### PR TITLE
fix in 'react-grid-panzoom' library connected with waiting for useRef…

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "main",
+  "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": [],
   "version": true,

--- a/.changeset/proud-camels-cry.md
+++ b/.changeset/proud-camels-cry.md
@@ -1,0 +1,5 @@
+---
+"react-web-builder": patch
+---
+
+fix in 'react-grid-panzoom' library connected with "waiting" for useRef api to load. in Builder it was causing that sometimes it was required to click on sidebar component "ListOrder" to load

--- a/package.json
+++ b/package.json
@@ -62,12 +62,7 @@
   },
   "keywords": [
     "react",
-    "pan",
-    "zoom",
-    "move",
-    "panzoom",
-    "moving",
-    "selecting"
+    "builder"
   ],
   "scripts": {
     "build:lib": "tsc && vite build --config vite.lib.config.ts",
@@ -150,7 +145,7 @@
     "react-accessible-accordion": "5.0.0",
     "react-color": "2.19.3",
     "react-frame-component": "5.2.6",
-    "react-grid-panzoom": "1.3.0",
+    "react-grid-panzoom": "1.4.1",
     "react-i18next": "13.2.2",
     "react-player": "2.13.0",
     "react-range": "1.8.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: 5.2.6
     version: 5.2.6(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
   react-grid-panzoom:
-    specifier: 1.3.0
-    version: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+    specifier: 1.4.1
+    version: 1.4.1(react-dom@18.2.0)(react@18.2.0)
   react-i18next:
     specifier: 13.2.2
     version: 13.2.2(i18next@23.5.1)(react-dom@18.2.0)(react@18.2.0)
@@ -6593,8 +6593,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-grid-panzoom@1.3.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-dYK1r21tifTiHsjz7/pq0fJ1Wdic6sSZLq/9D0vLCcggykV4xqeQOasVWWwYGgpEQECI6CgDOAJQMDCu65m2Qg==}
+  /react-grid-panzoom@1.4.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-VIOrj4NBzYRWQxFmLU3CBvAOg1ZqOTWrIGrtthYzh7F/KYt4H/ZX6Dw1vtsgHas3tfNC9XYgG0JwH5327++0GA==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'


### PR DESCRIPTION
… api to load. in Builder it was causing that sometimes it was required to click on sidebar component ListOrder to load